### PR TITLE
Fix remote url

### DIFF
--- a/lib/omniauth/strategies/picasa.rb
+++ b/lib/omniauth/strategies/picasa.rb
@@ -16,6 +16,10 @@ module OmniAuth
         :token_url     => '/o/oauth2/token'
       }
 
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
+
       def authorize_params
         base_scope_url = "https://www.googleapis.com/auth/"
         super.tap do |params|


### PR DESCRIPTION
## Summary

We need to have a correct callback override, currently query_params are considered as part of request 
in our fork it looks like :
https://github.com/omniauth/omniauth/blob/master/lib/omniauth/strategy.rb#L443

we need to make it similar to google implementation:
https://github.com/zquestz/omniauth-google-oauth2/blob/master/lib/omniauth/strategies/google_oauth2.rb#L99